### PR TITLE
Adding pdf choice menu and method to get pdf metadata

### DIFF
--- a/external_modules/pdfScraper/dev_methods.py
+++ b/external_modules/pdfScraper/dev_methods.py
@@ -6,3 +6,30 @@ __version__ = "1.0"
 __email__ = "jdjohn43@asu.edu"
 __date__ = "11/7/18"
 """
+import os
+
+
+# START This function displays the names of the PDS in the folder called "pdfs".
+def display_pdf_names(directory):
+    num = 1
+    fileChoice = 0
+    while(int(fileChoice) < 1 or int(fileChoice) > num):
+        num = 0
+        fileNames = []
+        path = directory
+        dirs = os.listdir(path)
+
+        # This prints all the files and directories inside "pdfs"
+        for file in dirs:
+            if "pdf" in file:
+                print(str(num + 1) + ". " + file)
+                fileNames.append(file)
+                num += 1
+        print("Please choose the file you would like to import. \n")
+        fileChoice = input()
+        if(int(fileChoice) < 1 or int(fileChoice) > num):
+            print(str(fileChoice) + " Please choose a valid number. \n")
+
+    currentWorkingFile = fileNames[int(fileChoice) - 1]
+    return currentWorkingFile
+# END This function displays the names of the PDS in the folder called "pdfs".

--- a/external_modules/pdfScraper/driver_all.py
+++ b/external_modules/pdfScraper/driver_all.py
@@ -7,45 +7,38 @@ __email__ = "jdjohn43@asu.edu"
 __date__ = "11/7/18"
 """
 
+import pdf_metadata_input
+import text_ui
 import process_tables
-import process_text
-from PyPDF2 import PdfFileReader
+import dev_methods
+# import process_text
+
 # process_text.convert_pdf_to_txt("pdfs/WassonandChoe_GCA_2009.pdf")
 
+# START This is getting the current pdfs in the pdf folder.
+chosen_pdf = dev_methods.display_pdf_names("pdfs/")
+print("\n You selected: " + chosen_pdf)
+# END This is getting the current pdfs in the pdf folder.
 
-def get_info(path):
-    with open(path, 'rb') as f:
-        pdf = PdfFileReader(f)
-        info = pdf.getDocumentInfo()
-        author = info.author
-        print(author)
+chosen_pdf = "pdfs/" + chosen_pdf
 
-
-
-path = "pdfs/WassonandChoe_GCA_2009.pdf"
-
-get_info(path)
+# START Getting Metadata
+print(pdf_metadata_input.get_metadata(chosen_pdf).author)
+# END Getting Metadata
 
 
+# choice = 0
+# while int(choice) < 3:
+#     text_ui.chooseProssesGui()
+#
+#     choice = input()
+#
+#     if int(choice) == 1:
+#         print("Text dump")
+#        # process.process_text()
+#     elif int(choice) == 2:
+#         process_tables.process_tables()
+#     elif int(choice) == 3:
+#         break
 
 
-# process_tables.display_pdf_names()
-
-choice = 0
-while int(choice) < 3:
-    print(" _________________________________________")
-    print("| Main Choice: Choose 1 of 5 choices:    |")
-    print("| Choose 1 to import text data from pdf. |")
-    print("| Choose 2 to import table data from pdf.|")
-    print("| Choose any other number to quit.       |")
-    print(" -----------------------------------------")
-
-    choice = input()
-
-    if int(choice) == 1:
-        print("Text dump")
-       # process.process_text()
-    elif int(choice) == 2:
-        process_tables.process_tables()
-    elif int(choice) == 3:
-        break

--- a/external_modules/pdfScraper/pdf_metadata_input.py
+++ b/external_modules/pdfScraper/pdf_metadata_input.py
@@ -8,4 +8,46 @@ __email__ = "jdjohn43@asu.edu"
 __date__ = "11/7/18"
 """
 
+import PyPDF2
+
+
+def get_metadata(path):
+    with open(path, 'rb') as f:
+        pdf = PyPDF2.PdfFileReader(f, strict=False)
+        info = pdf.getDocumentInfo()
+        author = info.author
+        print (info)
+        return info
+
+
+def get_num_pages(path):
+    # created a pdf file object
+    pdfFileObj = open(path)
+
+    # created a pdf reader object
+    pdfReader = PyPDF2.PdfFileReader(pdfFileObj)
+
+    # This is the number of pages contained in the current pdf
+    numPagesPDF = pdfReader.numPages
+
+    # The string name of the current pdf. This includes the path
+    pdfStringName = pdfFileObj.name
+
+def get_file_path_name(path):
+    # created a pdf file object
+    pdfFileObj = open(path)
+    # created a pdf reader object
+    pdfReader = PyPDF2.PdfFileReader(pdfFileObj)
+    # The string name of the current pdf. This includes the path
+    pdfStringName = pdfFileObj.name
+    return pdfStringName
+
+
+
+# path2 = "pdfs/WassonandChoe_GCA_2009.pdf"
+
+# print(get_info(path2))
+
+
+# TODO: Decide what we want to use out of the metadata.
 

--- a/external_modules/pdfScraper/text_ui.py
+++ b/external_modules/pdfScraper/text_ui.py
@@ -6,4 +6,19 @@ __authors__ = "Joshua Johnson"
 __version__ = "1.0"
 __email__ = "jdjohn43@asu.edu"
 __date__ = "11/7/18"
+
+https://docs.pytest.org/en/latest/getting-started.html#create-your-first-test
+is a good resource for testing.
 """
+
+
+def chooseProssesGui():
+    print(" _________________________________________")
+    print("| Main Choice: Choose 1 of 5 choices:    |")
+    print("| Choose 1 to import text data from pdf. |")
+    print("| Choose 2 to import table data from pdf.|")
+    print("| Choose any other number to quit.       |")
+    print(" -----------------------------------------")
+
+
+


### PR DESCRIPTION
This covers US144 tasks US263 and US264 and part of US225, task US227 only. 
To test this
1. Load the anaconda env called journalImport by typing "source activate journalImport" in your terminal.
2. open a terminal from the /irondb/external_modules/pdfScraper/ dir.
3. type "python driver_all"
4. It will output a string showing all of the metadata of the pdf that you choose.
5. Done.