### PR TITLE
Us143 - Returning json of Title and Author attribute

### DIFF
--- a/external_modules/node_python_working/test.py
+++ b/external_modules/node_python_working/test.py
@@ -11,19 +11,32 @@ __date__ = "11/7/18"
 
 import PyPDF2
 import sys
+import json
 
 
+def meta_to_json(info):
+    author = "EMPTY"
+    if (info.author):
+        author = info.author
 
+    title = "EMPTY"
+    if (info.title):
+        title = info.title
+    x = {
+        "author": author,
+        "title": title,
+    }
 
+    y = json.dumps(x)
 
+    print(y)
+    return info
 
-def get_metadata(paper):
-    with open("pdfs/WassonandChoe_GCA_2009.pdf", 'rb') as f:
+def get_metadata(path):
+    with open(path, 'rb') as f:
         pdf = PyPDF2.PdfFileReader(f, strict=False)
         info = pdf.getDocumentInfo()
-        author = info.author
-        print("The paper we will get metdadata from is " + paper + " The metdadata is as follows: " + str(info))
-        return info
+        meta_to_json(info)
 
 
 # START This function imports raw text import from a chosen pdf request.
@@ -40,5 +53,3 @@ def get_num_pages(path):
     # This is the number of pages contained in the current pdf
     numPagesPDF = pdfReader.numPages
     return numPagesPDF
-
-


### PR DESCRIPTION
To test...
1. Open terminal
2. Go to ironed/external_modules/node_python_working dir
3. Run npm install
4. Start the node server by typing "node app.js"
5. In your browser, got to localhost:8081
6. See that there is a son printed to screen of the title and author attribute to one of our pdfs. 

NOTE: Much of this was testing pdfs, which showed me that we need to do a lot more work in getting attributes from the text itself. In other words, this is one of several ways we can get this data, but we will need others to cover other cases.