### PR TITLE
US 293 T 355 updated conda env for linux to reflect current dependencies

### DIFF
--- a/external_modules/anaconda/env/linux64JournalImport.yml
+++ b/external_modules/anaconda/env/linux64JournalImport.yml
@@ -60,5 +60,5 @@ dependencies:
   - pip:
     - opencv-python==3.4.3.18
     - pypdf2==1.26.0
-prefix: /home/ken/anaconda3/envs/journalImport
+prefix: ~/anaconda3/envs/journalImport
 


### PR DESCRIPTION
This corrects versioning for dependencies on the Linux Conda environment.
On Linux:
```
conda remove --name journalImport --all
cd ~/irondb/external_modules/anaconda/env   ////where ~ is dir where proj is stored
conda env create -f linux64JournalImport.yml
conda activate journalImport
```
When satisfied `conda deactivate`

