### PR TITLE
Us184 Title Extraction from Text

### DIFF
--- a/external_modules/pdfScraper/nlp4metadata.py
+++ b/external_modules/pdfScraper/nlp4metadata.py
@@ -11,7 +11,7 @@ import os
 import pdf_text
 
 # global variables
-path = os.path.abspath('pdfs')
+path = os.path.abspath('pdfs') + '/'
 #path = 'C:/Users/Hajar/Desktop/Psyhe NASA/irondb/external_modules/pdfScraper/pdfs/'
 page_num = 1
 
@@ -19,7 +19,7 @@ page_num = 1
 # extracts the title from a user specified pdf
 def truncated_title(pdf_name):
     global page_num
-    random_page = pdf_text.convert_pdf_to_txt(path + '/' + pdf_name, page_num)
+    random_page = pdf_text.convert_pdf_to_txt(path + pdf_name, page_num)
 
     # extracts the truncated title from the top of a random page
     title_trunc = random_page.split('\n', 1)[0]


### PR DESCRIPTION
1. Navigate to directory: irondb\external_modules\pdfScraper
2. Run nlp4metadata.py in any compiler (Sublime doesn't take user input without a plugin, uncomment lines 52-53 for Sublime, and comment out lines 47-49), or run "python nlp4metadata.py" in terminal
3. Enter pdf name with extension (.pdf)
    Currently working perfectly for:
        - Wassonetal_GCA_2007
        - WassonandRichardson_GCA_2011
        - WassonandChoe_GCA_2009
4. Press enter and wait for hell to break loose
5. Should get the truncated title and full title printed out in separate lines
6. Done

Note: The rest of the pdfs will give mixed results for mixed reasons. WassonandKallemeyn_GCA_2002 technically works but only outputs first line of full title. Avoid the 70s and 1995, they will get you into an infinite loop. The 80s have sideways tables which throws everything off (researchers were wild back then.) The one from the 60s made the title an image so pdfminer doesn't retrieve it (the 60s in general were a lie.) And the author of the one from from 2017 decided to plaster his name at the top of every page so that throws off the truncated title which is used to locate the full title; nlp is the only remedy for narcissism.
