### PR TITLE
Us319 Publishing Date Extraction from Text

### DIFF
--- a/external_modules/pdfScraper/nlp4metadata.py
+++ b/external_modules/pdfScraper/nlp4metadata.py
@@ -8,15 +8,23 @@ __email__ = "hajar.boughoula@gmail.com"
 __date__ = "11/25/18"
 
 import os
+import re
 import pdf_text
 
 # global variables
 path = os.path.abspath('pdfs') + '/'
-#path = 'C:/Users/Hajar/Desktop/Psyhe NASA/irondb/external_modules/pdfScraper/pdfs/'
 page_num = 1
 
 
-# extracts the title from a user specified pdf
+# stages relevant parts of the first page of a pdf for data extraction
+def relevant_text(pdf_name):
+    page = pdf_text.convert_pdf_to_txt(path+pdf_name, 0)
+    text = (page.split("Abs", 1)[0])
+
+    return text
+
+
+# extracts truncated title from top of any page in the pdf
 def truncated_title(pdf_name):
     global page_num
     random_page = pdf_text.convert_pdf_to_txt(path + pdf_name, page_num)
@@ -30,10 +38,9 @@ def truncated_title(pdf_name):
     return title_trunc
 
 
-# finds truncated title in first page to return full title
+# extracts full title from the first page of pdf using truncated title
 def extract_title(pdf_name):
-    first_page = pdf_text.convert_pdf_to_txt(path+pdf_name, 0)
-    relevant_data = (first_page.split("Abs", 1)[0])
+    relevant_data = relevant_text(pdf_name)
 
     title_split = truncated_title(pdf_name).split()
     title_tagword = title_split[0] + ' ' + title_split[1]
@@ -43,13 +50,20 @@ def extract_title(pdf_name):
     return title_full
 
 
-# or title[0].isdigit()
+# extracts publishing date from pdf text
+def extract_date(pdf_name):
+    relevant_data = relevant_text(pdf_name).split()
+    for ch in relevant_data:
+        date = (re.search(r'.*([1-3][0-9]{3})', ch))
+
+    return date.group(1)
+
 
 # WARNING: user input not supported in Sublime
+# in Sublime: comment out user input and replace user_pdf with pdf name
 user_pdf = input("Enter PDF name with extension: ")
 print("Truncated Title:        " + truncated_title(user_pdf))
 print("Full Title:             " + extract_title(user_pdf))
+print("Publishing Date:        " + extract_date(user_pdf))
 
-# in Sublime replace name of PDF here
-# print("Truncated Title:        " + truncated_title('WassonandChoe_GCA_2009.pdf'))
-# print("Full Title:             " + extract_title('WassonandChoe_GCA_2009.pdf'))
+# print(relevant_text('WassonandChoe_GCA_2009.pdf'))


### PR DESCRIPTION
1. Navigate to directory: irondb\external_modules\pdfScraper
2. Run nlp4metadata.py in any compiler (Sublime doesn't take user input without a plugin, follow comment directions in line 63), or run "python nlp4metadata.py" from the terminal.
3. Enter PDF name with extension (.pdf)
    Currently working for:
        - WassonandKimberlin_GCA_1967.pdf
        - WassonandKallemeyn_GCA_2002.pdf
        - Wassonetal_GCA_2007.pdf
        - WassonandChoe_GCA_2009.pdf
        - WassonandRichardson_GCA_2011.pdf
        - Wasson_GCA_2017.pdf
4. Press enter; you should get the publishing date printed out beneath the full and truncated title.
5. Done.