### PR TITLE
Us434

### DIFF
--- a/external_modules/pdfScraper/nlp4metadata.py
+++ b/external_modules/pdfScraper/nlp4metadata.py
@@ -8,14 +8,13 @@ __email__ = "hajar.boughoula@gmail.com"
 __date__ = "11/25/18"
 
 import os
-import nltk.tokenize
+import nltk
+from nltk import tokenize, pos_tag
 import re
-#import pprint
 import pdf_text
 
 # global variables
 path = os.path.abspath('pdfs') + '/'
-tokenizer = nltk.tokenize.RegexpTokenizer(r'\w+|\S+')
 page_num_title = 1
 page_num_authors = 1
 
@@ -28,13 +27,20 @@ def relevant_text(pdf_name):
     return text
 
 
-# preprocesses the first page of the pdf using NLTK
+# preprocesses the staged parts of the pdf using NLTK
 def staged_text(pdf_name):
+    tokenizer = tokenize.RegexpTokenizer(r'\w+|\S+')
     relevant_data = relevant_text(pdf_name)
 
-    chopped_up = tokenizer.tokenize(relevant_data)
+    #chopped_up = tokenizer.tokenize(relevant_data)
 
-    return chopped_up
+    try:
+        tagged = pos_tag(tokenizer.tokenize(relevant_data))
+    except LookupError:
+        nltk.download('averaged_perceptron_tagger')
+        print('******** POS_TAG DEPENDENCIES DOWNLOADED. PLEASE RUN AGAIN. ********')
+
+    return tagged
 
 
 # extracts truncated title from top of any page in the pdf


### PR DESCRIPTION
This little bit simply tokenizes a specific section of any paper you feed it and does part of speech (pos) tagging to stage that text for data extraction. Will be used for recognizing and extracting the title, author, and source.

To Test:

1. cd irondb/external_modules/pdfScraper
2. source activate journalImport
3. python nlp4metadata.py
4. enter paper name with extension (Suggestion: WassonandChoe_GCA_2009.pdf)
5. Output should be a tokenized and pos tagged list of tuples similar to what's in the screenshot

This only takes a fraction of a second to run if you use a "reasonable" paper.

Expected output should look similar to this:

<img width="569" alt="screen shot 2019-01-19 at 8 34 33 am" src="https://user-images.githubusercontent.com/26435230/51429327-e91f5800-1bca-11e9-8993-9c33a903e33c.png">
