### PR TITLE
Us372

### DIFF
--- a/external_modules/pdfScraper/nlp4metadata.py
+++ b/external_modules/pdfScraper/nlp4metadata.py
@@ -57,18 +57,23 @@ def truncated_title(pdf_name):
 # extracts full title from the first page of pdf using truncated title
 def extract_title(pdf_name):
 
+    title_full = "Title not found"
     relevant_data = relevant_text(pdf_name, extract_authors(pdf_name)[0])
 
     pattern = "NOUN-PHRASE: {<DT>?<NNP>*<NN>*<NNS>*<:><JJ>*<NN>*<IN>*<DT>*<NNP>*<NN>*}"
     chunkr = nltk.RegexpParser(pattern)
-    title_full = chunkr.parse(stage_text(relevant_data))
+    chunks = chunkr.parse(stage_text(relevant_data))
+
+    for chunk in chunks:
+        if type(chunk) == nltk.tree.Tree:
+            if chunk.label() == 'NOUN-PHRASE':
+                title_full =   " ".join([leaf[0] for leaf in chunk.leaves()])
 
     #title_split = truncated_title(pdf_name).split()
     #title_tagword = title_split[0] + ' ' + title_split[1]
     #title_index = (relevant_data.lower()).find(title_tagword.lower())
     #title_full = relevant_data[:title_index].rsplit('\n\n', 1)[1] + relevant_data[title_index:].split('\n', 1)[0]
 
-    #return title_full
     return title_full
 
 


### PR DESCRIPTION
This code extracts the title from a specific paper using NLP. Currently works on WassonandChoe_GCA_2009 due to the regex pattern. The point of this PR/US is to pull out a title using NLP. In a future US I'll work on coming up with a more generalized regex pattern that works on most papers (will need a lot of creative thinking etc.)

To Test:

1. cd irondb/external_modules/pdfScraper
2. source activate journalImport
3. python nlp4metadata.py
4. enter WassonandChoe_GCA_2009.pdf
5. Verify that it returns the title of the paper (I am aware of the extra space before the colon. Will fix asap)