### PR TITLE
Us390

### DIFF
--- a/external_modules/pdfScraper/nlp4metadata.py
+++ b/external_modules/pdfScraper/nlp4metadata.py
@@ -257,4 +257,5 @@ def extract_source(pdf_name):
 
 
 paper = input("Enter name of paper with extension (.pdf): ")
+print(extract_title(paper))
 print(extract_authors(paper))


### PR DESCRIPTION
This code extracts the author(s) from a specific paper using NLP. Currently works on WassonandChoe_GCA_2009 due to the regex pattern. It probably will work with most papers that have 2 authors if you want to experiment, but in a future US I'll work on coming up with a more generalized regex pattern that works on all papers.

To Test:

1. cd irondb/external_modules/pdfScraper
2. source activate journalImport
3. python nlp4metadata.py
4. enter WassonandChoe_GCA_2009.pdf
5. Verify that it returns the title and authors of the paper

Note 1: The nlp extraction of the title depends on the successful extraction of the authors.
Note 2: The space before the colon in the title is now fixed by considering punctuation as part of the previous token instead of an independent token.