### PR TITLE
Making the table driver file ready to debug final 5 bugs to fix for g…

### DIFF
--- a/external_modules/pdfScraper/table_driver.py
+++ b/external_modules/pdfScraper/table_driver.py
@@ -68,8 +68,29 @@ def input_number(message, hiNum, loNum):
 # /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-# START GETTING THE TABLES /////////////////////////////////////////////////////////////////////////////////////////////////////
-# ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+# START FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS
+# START FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS
+# START FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS
+#
+#
+#
+# START 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT
+# START 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT
+
+# START Getting total pages of pdf
+def get_num_pages(path):
+    # created a pdf file object
+    pdfFileObj = open(path, 'rb')
+
+    # created a pdf reader object
+    pdfReader = PyPDF2.PdfFileReader(pdfFileObj)
+
+    # This is the number of pages contained in the current pdf
+    numPagesPDF = pdfReader.numPages
+    return numPagesPDF
+# END Getting total pages of pdf
 
 # START This function imports raw text import from a chosen pdf request.
 def convert_pdf_to_txt(path, pageNo=0):
@@ -103,9 +124,13 @@ def convert_pdf_to_txt_looper(path, num_pages):
     return individual_pages
 # END This function puts each page of text in its own slot in an array of strings
 
-# END GETTING THE TABLES //////////////////////////////////////////////////////////////////
-# ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
+# END 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT
+# END 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT
+#
+#
+#
+# START 1. FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES
+# START 1. FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES
 
 # START This function finds pages in a pdf that have tables on it and makes an array of these pages in order to iterarte through
 # them later.
@@ -124,18 +149,136 @@ def look_for_tables(pages, num_pages):
 # END This function finds pages in a pdf that have tables on it and makes an array of these pages in order to iterarte through
 # them later.
 
-# START Getting total pages of pdf
-def get_num_pages(path):
-    # created a pdf file object
-    pdfFileObj = open(path, 'rb')
 
-    # created a pdf reader object
-    pdfReader = PyPDF2.PdfFileReader(pdfFileObj)
+# END 1. FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES
+# END 1. FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES FINDING PAGES WITH TABLES
+#
+#
+#
+# START 2. GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES
+# START 2. GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES
 
-    # This is the number of pages contained in the current pdf
-    numPagesPDF = pdfReader.numPages
-    return numPagesPDF
-# END Getting total pages of pdf
+def process_tables_get(path, page):
+    dataframe_list = read_pdf(path, output_format="dataframe", encoding="utf-8",  multiple_tables=True, pages=int(page), silent=True)
+    print("This is the size of the DF: " + str(len(dataframe_list)))
+    if len(dataframe_list) > 0:
+        for i in dataframe_list[0].iterrows():
+            print(i)
+
+    if len(dataframe_list) > 1:
+        print("This is 2nd DF: ")
+        for i in dataframe_list[1].iterrows():
+            print(i)
+    return dataframe_list
+
+
+# END 2. GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES
+# END 2. GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES GETTING TABLES
+#
+#
+#
+# START 3. MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES
+# START 3. MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES
+
+def process_tables_mark(df):
+    row_count, col_count = df.shape
+    x = 0
+    while x < row_count:
+        y = 0
+        while y < col_count:
+            print(str(df[y][x]))
+            if len(str(df[y][x])) > 20:
+                df[y][x] = "REMOVE"
+            y += 1
+        x += 1
+        # print(df)
+    return df
+
+
+# END 3. MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES
+# END 3. MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES MARKING THE TABLES
+#
+#
+#
+# START 4. REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS
+# START 4. REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS
+
+def process_tables_clean(mdf):
+    row_count, col_count = mdf.shape
+    # print(mdf.shape)
+    # print(mdf)
+    col_iter = col_count - 1
+    while col_iter >= 0:
+        tally_col = row_iter = 0
+        while row_iter < row_count:
+            value_to_test = str(mdf.iloc[row_iter][col_iter])
+            if value_to_test == "REMOVE":
+                tally_col += 1
+            row_iter += 1
+        if tally_col / row_count > .49:
+            if mdf.empty:
+                print('DataFrame is empty!')
+            else:
+                # print(mdf)
+                mdf = mdf.drop(mdf.columns[col_iter], axis=1)
+        col_iter -= 1
+    return mdf
+
+# END 4. REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS
+# END 4. REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS REMOVING BAD ROWS and COLS
+#
+#
+#
+# START 5. PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON
+# START 5. PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON
+
+def table_to_json(df_list):
+    table_json = {}
+    if len(df_list) > 0:
+        for x in df_list:
+            table_json = process_tables_mark(x).to_json(orient='index')
+    return table_json
+
+# END 5. PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON
+# END 5. PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON PUTTING TABLES INTO JSON
+#
+#
+#
+# END FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS
+# END FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS
+# END FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS FUNCTIONS
+
+
+def process_table_engine(path, page):
+    table_rec = process_tables_get(path, page)
+    print(table_rec)
+
+    # if len(table_rec) > 0:
+    #     for x in table_rec:
+    #         table_marked = process_tables_mark(x)
+    #         # print(table_marked)
+    #         table_cleaned = process_tables_clean(table_marked)
+    #         # print(table_cleaned)
+    #         return json.loads((table_cleaned.to_json(double_precision=10, force_ascii=True,
+    #
+
+
+
+
+
+
+
+#
+# tableNum = 1
+# for x in array_tables:
+#     print("Table: " + str(tableNum))
+#     print( str(x))
+#     print("\n")
+#     tableNum += 1
+
+# START DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER
+# START DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER
+# START DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER
 
 
 # START This is getting the current pdfs in the pdf folder.
@@ -169,140 +312,6 @@ accepted_table = 1
 table_json_to_send = {}
 array_tables = []
 
-# START PROCESSING THE TABLES//////////////////////////////////////////////////////////////////////////////////////////////////
-# //////////////////////////////////////////////////////////////////////////////////////////////////
-# //////////////////////////////////////////////////////////////////////////////////////////////////
-##################################################################################################################################
-# Function Name: process_tables_clean
-# Function Purpose: This function gets rid of unwanted cols and rows.
-# Function Inputs: a dataframe with information from.a table.
-# Function Output:A clean dataframe
-##################################################################################################################################
-def process_tables_clean(mdf):
-    row_count, col_count = mdf.shape
-    # print(mdf.shape)
-    # print(mdf)
-    col_iter = col_count - 1
-    while col_iter >= 0:
-        tally_col = row_iter = 0
-        while row_iter < row_count:
-            value_to_test = str(mdf.iloc[row_iter][col_iter])
-            if value_to_test == "REMOVE":
-                tally_col += 1
-            row_iter += 1
-        if tally_col / row_count > .49:
-            if mdf.empty:
-                print('DataFrame is empty!')
-            else:
-                # print(mdf)
-                mdf = mdf.drop(mdf.columns[col_iter], axis=1)
-        col_iter -= 1
-    return mdf
-# END This function gets rid of unwanted cols and rows.
-
-
-# START
-##################################################################################################################################
-# Function Name: process_tables_mark
-# Function Purpose: This function marks fields that have bed data in them by putting teh work REMOVE in it's place.
-# Function Inputs: A raw unfiltered dataframe with info from a table.
-# Function Output: A dataframe with values marked for removal.
-##################################################################################################################################
-def process_tables_mark(df):
-    row_count, col_count = df.shape
-    x = 0
-    while x < row_count:
-        y = 0
-        while y < col_count:
-            print(str(df[y][x]))
-            if len(str(df[y][x])) > 20:
-                df[y][x] = "REMOVE"
-            y += 1
-        x += 1
-        # print(df)
-    return df
-# END This function marks fields that have bed data in them by putting teh work REMOVE in it's place.
-
-
-def process_tables_mark_temp(df):
-    row_count, col_count = df.shape
-    x = 0
-    while x < row_count:
-        y = 0
-        while y < col_count:
-            print(str(df[y][x]))
-            if len(str(df[y][x])) > 20:
-                    # or rules.value_is_lc_frag(str(df[y][x])):
-                df[y][x] = "REMOVE"
-            y += 1
-        x += 1
-        # print(df)
-    return df
-
-
-
-
-# START
-##################################################################################################################################
-# Function Name:process_tables_get
-# Function Purpose: This function processes a table import from a chosen pdf request.
-# Function Inputs: path:The path to find the pdf. page: The page to look at.
-# Function Output:A list of dataframes with table information in them.
-##################################################################################################################################
-def process_tables_get(path, page):
-    dataframe_list = read_pdf(path, output_format="dataframe", encoding="utf-8",  multiple_tables=True, pages=int(page), silent=True)
-    print("This is the size of the DF: " + str(len(dataframe_list)))
-    if len(dataframe_list) > 0:
-        for i in dataframe_list[0].iterrows():
-            print(i)
-
-    if len(dataframe_list) > 1:
-        print("This is 2nd DF: ")
-        for i in dataframe_list[1].iterrows():
-            print(i)
-    return dataframe_list
-# END This function processes a table import request.
-
-##################################################################################################################################
-# Function Name: table_to_json
-# Function Purpose: The function converts the cleaned up dataframe to a json string.
-# Function Inputs: A list of dataframes.
-# Function Output: a json string of the information from a cleaned up table.
-##################################################################################################################################
-def table_to_json(df_list):
-    table_json = {}
-    if len(df_list) > 0:
-        for x in df_list:
-            table_json = process_tables_mark(x).to_json(orient='index')
-    return table_json
-
-##################################################################################################################################
-# Function Name: process_table_engine
-# Function Purpose: This is driver code that specifically drives looking at the provided table information, filtering the table
-# info and returning the cleaned up tables.
-# Function Inputs: Path: The path of the file. page: The page that the scraper is looking at.
-# Function Output: A json string of the table information.
-##################################################################################################################################
-def process_table_engine(path, page):
-    table_rec = process_tables_get(path, page)
-    print(table_rec)
-
-    # if len(table_rec) > 0:
-    #     for x in table_rec:
-    #         table_marked = process_tables_mark(x)
-    #         # print(table_marked)
-    #         table_cleaned = process_tables_clean(table_marked)
-    #         # print(table_cleaned)
-    #         return json.loads((table_cleaned.to_json(double_precision=10, force_ascii=True,
-    #
-
-
-
-
-# END PROCESSING THE TABLES//////////////////////////////////////////////////////////////////////////////////////////////////
-# //////////////////////////////////////////////////////////////////////////////////////////////////
-# //////////////////////////////////////////////////////////////////////////////////////////////////
-
 while pwt_count < more:
     test = process_table_engine(chosen_pdf, int(pages_with_table[pwt_count]))
     if str(test) != "None":
@@ -317,11 +326,6 @@ print(array_tables)
 # END Get tables 1 page at a time.
 
 
-#
-# tableNum = 1
-# for x in array_tables:
-#     print("Table: " + str(tableNum))
-#     print( str(x))
-#     print("\n")
-#     tableNum += 1
-
+# END DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER
+# END DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER
+# END DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER DRIVER


### PR DESCRIPTION
…etting and cleaning up tables.

Go to  external_modules/pdfScraper/table_driver.py

I now have the 6 different phases of getting the tables sectioned off in a way that will allow me to debug in a linear way that matches my testing document.
Feel free to accept this without the check or if you want to go through each pdf and see that I am now simply verifying that all tables get all tables (unless the page is vertical), including 2 tables on the same page. 

A way to verify this is to look for the keyword "2nd" in the print out. If you choose a doc that you know has 2 tables on one page, look for the corresponding  keyword to show that it is indeed pulled.
If you want to do this and have more questions... ask me in slack.