### PR TITLE
Us403

### DIFF
--- a/external_modules/pdfScraper/nlp4metadata.py
+++ b/external_modules/pdfScraper/nlp4metadata.py
@@ -153,13 +153,19 @@ def extract_authors(pdf_name):
     return authors_full
 
 
-# extracts publishing date from pdf text
+# extracts publishing date from the pdf text
 def extract_date(pdf_name):
-    relevant_data = relevant_text(pdf_name, "Abs").split()
-    for ch in relevant_data:
-        date = (re.search(r'.*([1-3][0-9]{3})', ch))
+    relevant_data = relevant_text(pdf_name, "Abs").lower()
+    if "publish" in relevant_data:
+        relevant_data = relevant_data.rsplit("publish", 1)[1]
+    elif "available" in relevant_data:
+        relevant_data = relevant_data.rsplit("available", 1)[1]
+    elif "accept" in relevant_data:
+        relevant_data = relevant_data.rsplit("accept", 1)[1]
 
-    return date.group(1)
+    date = re.search(r'[1-3][0-9]{3}', relevant_data)
+
+    return date.group()
 
 
 # extracts source URL from the pdf text


### PR DESCRIPTION
This code extracts the publishing date from a specific paper using text context and ReGex. Currently works on all papers except for five: 1995, 1984, 1990, 1971, and 1970. All the other fifteen papers work.

To Test:

1. cd irondb/external_modules/pdfScraper
2. source activate journalImport
3. python nlp4metadata.py
4. enter paper name (cool suggestion: Kracheretal_GCA_1980.pdf)
5. Verify that it returns the **publishing date** (this is the date that the paper was "published"/"accepted" or became "available", NOT the copyright date or the date that the journal was published; pending further feedback from Dr. Schrader.)

<img width="568" alt="screen shot 2019-02-02 at 7 51 33 am" src="https://user-images.githubusercontent.com/26435230/52165544-7ed4e000-26bf-11e9-9f99-b88e2af846bf.png">
