### PR TITLE
I added functionality to find tables that are continued on the next p…

### DIFF
--- a/external_modules/pdfScraper/table_driver.py
+++ b/external_modules/pdfScraper/table_driver.py
@@ -24,6 +24,7 @@ from pdfminer.pdfpage import PDFPage
 
 master_json = ""
 pages_with_tables = []
+pages_with_continue = []
 master_dict_tables = {}
 pdf = ["pdfs/WassonandRichardson_GCA_2011.pdf",
        "pdfs/WassonandChoe_GCA_2009.pdf",
@@ -38,7 +39,7 @@ pdf = ["pdfs/WassonandRichardson_GCA_2011.pdf",
        "pdfs/RuzickaandHutson2010.pdf",
        "pdfs/spinTest.pdf"]
 
-chosen_pdf = pdf[1]
+chosen_pdf = pdf[10]
 
 
 # START 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT 0. GETTING THE TEXT
@@ -92,11 +93,11 @@ def row_by_row(mdf):
                 row_remove += 1
             if str(mdf.iloc[row][col]) == "nan":
                 row_null += 1
-            print(str(mdf.iloc[row][col]))
-            print("THIS IS REMOVE TALLY: " + str(row_remove))
-            print("THIS IS NULL TALLY: " + str(row_null))
-            print("THIS IS Amount of Rows: " + str(mdf.shape[0]))
-            print(mdf)
+            # print(str(mdf.iloc[row][col]))
+            # print("THIS IS REMOVE TALLY: " + str(row_remove))
+            # print("THIS IS NULL TALLY: " + str(row_null))
+            # print("THIS IS Amount of Rows: " + str(mdf.shape[0]))
+            # print(mdf)
         if mdf.shape[1] - (row_remove + row_null) < 2:
             mdf = mdf.drop(row)
             if mdf.empty:
@@ -112,12 +113,12 @@ def column_by_column(mdf):
                 col_remove += 1
             if str(mdf.iloc[row][col]) == "nan":
                 col_null += 1
-            print(str(mdf.iloc[row][col]))
-            print("THIS IS REMOVE TALLY: " + str(col_remove))
-            print("THIS IS NULL TALLY: " + str(col_null))
-            print("THIS IS Amount of Col: " + str(mdf.shape[0]))
-            print("THIS IS Cols - bads: " + str(mdf.shape[0] - (col_remove + col_null)))
-        print("This is Column Number:" + str(col))
+        #     print(str(mdf.iloc[row][col]))
+        #     print("THIS IS REMOVE TALLY: " + str(col_remove))
+        #     print("THIS IS NULL TALLY: " + str(col_null))
+        #     print("THIS IS Amount of Col: " + str(mdf.shape[0]))
+        #     print("THIS IS Cols - bads: " + str(mdf.shape[0] - (col_remove + col_null)))
+        # print("This is Column Number:" + str(col))
         # print("This is cols divided by bads: " + str(mdf.shape[0]/(col_remove + col_null)))
         print(mdf)
         if mdf.shape[0] - (col_remove + col_null) < 2 or(col_remove + col_null)/ mdf.shape[0] > .85:
@@ -139,13 +140,21 @@ print("There are " + str(total_pages) + " pages in this document.")
 text = convert_pdf_to_txt_looper(chosen_pdf, total_pages)
 # End get text from pdf.
 
-# START Getting pages that have tables on them.
+# START Getting pages that have tables on them. looking for page 15
 for iterate in range(total_pages):
     splitted = text[iterate].split()
-    if splitted[0] == "Table" or text[iterate].find('\nTable ') > 0  or bool(re.search(r'\w\n\w\n\w\n?', text[iterate])):
+    if splitted[0] == "Table" or text[iterate].find('\nTable ') > 0 or bool(re.search(r'\w\n\w\n\w\n', text[iterate])):
         print("############# Table exists on Page " + str(iterate + 1) + " #############" + "\n Word: "
               + str(text[iterate].find('\nTable ')))
         pages_with_tables.append(iterate + 1)
+        # print("This is Pages With Tables: " + str(pages_with_tables))
+
+if pages_with_tables:
+    for page in pages_with_tables:
+        if re.search(r'Continued\S\n', text[page], re.IGNORECASE):
+            pages_with_continue.append(page + 1)
+print("Pages with CONTINUED: " + str(pages_with_continue))
+
 # END Getting pages that have tables on them.
 
 # START Get tables 1 page at a time.
@@ -165,7 +174,9 @@ if len(tables_rec_from_page) > 0:
                     df[y][x] = "REMOVE"
 print("START THE MARKING START THE MARKING START THE MARKING START THE MARKING START THE MARKING START THE MARKING ")
 ind = 3
-print(tables_rec_from_page[ind])
+# print(tables_rec_from_page[ind])
+
+
 # End Marking the fields for removal
 
 print("Length of array with DFs: " + str(len(tables_rec_from_page)))
@@ -179,7 +190,11 @@ tables_rec_from_page[ind] = row_by_row(tables_rec_from_page[ind])
 #tables_rec_from_page[ind] = column_by_column(tables_rec_from_page[ind])
 #
 #
-print(tables_rec_from_page[ind])
+
+
+# print(tables_rec_from_page[ind])
+
+
 # table_cleaned = process_tables_clean(table_marked)
 # # print(table_cleaned)
 # return json.loads((table_cleaned.to_json(double_precision=10, force_ascii=True,date_unit='ms', lines=False)))


### PR DESCRIPTION
…age.

Go to Command line
source activate journalImport
Go to the external_modules/pdfScraper/ dir and run
table_driver.py
The output will be...

PdfReadWarning: Xref table not zero-indexed. ID numbers for objects will be corrected. [pdf.py:1736]
There are 40 pages in this document.
############# Table exists on Page 2 #############
 Word: 6635
############# Table exists on Page 3 #############
 Word: 79
############# Table exists on Page 6 #############
 Word: 1446
############# Table exists on Page 9 #############
 Word: 2049
############# Table exists on Page 12 #############
 Word: -1
############# Table exists on Page 13 #############
 Word: -1
############# Table exists on Page 14 #############
 Word: -1
############# Table exists on Page 15 #############
 Word: -1
############# Table exists on Page 16 #############
 Word: -1
############# Table exists on Page 17 #############
 Word: 79
Pages with CONTINUED: [7, 15]
Feb 15, 2019 5:48:11 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:11 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C2 (3) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:12 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:12 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C2 (3) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:12 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C176 (2) in font FEJJLD+AdvPSSym
Feb 15, 2019 5:48:13 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:13 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C176 (2) in font FEJJLD+AdvPSSym
Feb 15, 2019 5:48:13 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C1 (4) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:13 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:13 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C176 (2) in font FEJJLD+AdvPSSym
Feb 15, 2019 5:48:13 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C1 (4) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:14 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C1 (4) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:15 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C0 (5) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:16 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:16 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C2 (3) in font FEJJLC+AdvP4C4E74
Feb 15, 2019 5:48:16 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C176 (2) in font FEJJLD+AdvPSSym
Feb 15, 2019 5:48:16 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C0 (5) in font FEJJLC+AdvP4C4E74
9
START THE MARKING START THE MARKING START THE MARKING START THE MARKING START THE MARKING START THE MARKING 
Length of array with DFs: 9
Rows: 17 Cols: 14
row_by_row************************************************************************************************************
Rows: 17 Cols: 14

The thing to note is this "Pages with CONTINUED: [7, 15]"
There is a table that is continued on page 15. The continue that is on page 7 is bogus, but will be filtered out by code that requires tables with continue on them have to match the dimensions of the table on the previous page to be valid.
