### PR TITLE
Us611

### DIFF
--- a/external_modules/pdfScraper/nlp4metadata.py
+++ b/external_modules/pdfScraper/nlp4metadata.py
@@ -109,10 +109,15 @@ def stage_text(txt):
     try:
         sentences = nltk.word_tokenize(txt)
     except LookupError:
+        nltk.download('punkt')
         nltk.download('averaged_perceptron_tagger') # pos_tag dependency
         nltk.download('maxent_ne_chunker') # ne_chunk dependency
         nltk.download('words') # ne_chunk dependency
-    
+        print("\n")
+        print("                  ******************************************")
+        print("                  DEPENDENCIES DOWNLOADED. PLEASE RUN AGAIN")
+        print("                  ******************************************\n\n")
+
     return sentences
 
 


### PR DESCRIPTION
This code extracts all authors (English named and non-English named) from a specific paper using NLTK named entity recognition. Currently works perfectly ONLY FOR WassonandChoe_GCA_2009. The rest of the papers return rubbish sometimes because NLTK's named entity recognition returns false positives for the PERSON tag. This will be fixed in optimizations.

To Test:

1. cd irondb/external_modules/pdfScraper
2. source activate journalImport
3. python nlp4metadata.py
4. if you see a message in the console about NLTK dependencies being downloaded, please run step 3 again once the download process is finished.
5. enter WassonandChoe_GCA_2009.pdf
6. Verify that it returns both English-named and non-English named author(s)