### PR TITLE
I added a script that will handle all signal page special use case ta…

### DIFF
--- a/external_modules/pdfScraper/table_driver_single.py
+++ b/external_modules/pdfScraper/table_driver_single.py
@@ -1,0 +1,42 @@
+import PyPDF2
+import sys
+from tabula import read_pdf
+import pandas as pd
+pd.options.display.max_rows = 999
+pd.options.display.max_columns = 999
+
+# sys.argv[0]  = path of python script that is running
+# sys.argv[1]  = Name of file
+# sys.argv[2]  = Page number
+# sys.argv[3] = Number of task to call.
+# sys.argv[4]  = Direction to flip page
+
+
+print(sys.argv[1])
+
+pdf_name = "pdfs/" + str(sys.argv[1])
+pagenum = int(sys.argv[2]) - 1
+
+
+def turn_page():
+    page_in = open(pdf_name, 'rb')
+    page_reader = PyPDF2.PdfFileReader(page_in)
+    page_writer = PyPDF2.PdfFileWriter()
+
+    page = page_reader.getPage(pagenum)
+    page.rotateClockwise(90)
+    page_writer.addPage(page)
+
+    pdf_out = open('rotatedPage.pdf', 'wb')
+    page_writer.write(pdf_out)
+    pdf_out.close()
+    page_in.close()
+
+
+if int(sys.argv[3]) == 0:
+    turn_page()
+    # START Get tables 1 page at a time.
+    tables_rec_from_page = read_pdf('rotatedPage.pdf', output_format="dataframe", encoding="utf-8", multiple_tables=True,
+                                    pages=0, silent=True)
+    print(tables_rec_from_page)
+


### PR DESCRIPTION
…ble gets. I also I a page rotator that takes a name of a file, a page number, a number of task to run and a direction to flip the page.

Go to Command line
source activate journalImport
Go to the external_modules/pdfScraper/ dir and run
python table_driver_single.py Wasson_2010.pdf 5 0 90
This means you are passing in args for the paper name, the page you want to turn, the task you want to run and the degrees you want to rotate the page.
This will create a file called rotatedPage.pdf, which will be a single page from the original pdf but turned.
Troy and I will work on how the end user will send this data to the server (hopefully this sprint).

You will also see the rotated table imported and printed to console.

The output will be...

PdfReadWarning: Xref table not zero-indexed. ID numbers for objects will be corrected. [pdf.py:1736]
Wasson_2010.pdf
Feb 19, 2019 4:25:39 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C0 (3) in font JHLBFB+AdvP4C4E74
Feb 19, 2019 4:25:39 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font JHLBFB+AdvP4C4E74
Feb 19, 2019 4:25:40 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C0 (3) in font JHLBFB+AdvP4C4E74
Feb 19, 2019 4:25:40 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font JHLBFB+AdvP4C4E74
[                  0    1      2      3     4   \
0           Zerhamra   65   4.95   78.8   175   
1           NWA 4704   39   4.89   89.0   154   
2             Kharga   21   4.37  117.7   200   
3           NWA 0959   49   4.27   94.8   128   
4                NaN  NaN    NaN    NaN   NaN   
5           NWA 2676  412   4.67   83.9   176   
6          El Qoseir   24   6.56  135.0   873   
7        Gebel Kamil   32   7.43  207.7   486   
8           NWA 0176  430   4.14   86.0   300   
9                NaN  NaN    NaN    NaN   NaN   
10          NWA 0859   12  12.93  163.4   291   
11          NWA 4702  208   4.37   54.3   115   
12          NWA 4705   34  13.19  200.1   339   
13          NWA 6259    9   6.12    426  3400   
14   Dar al Gani 406  NaN   4.39   67.1   NaN   
15   Dar al Gani 413  NaN   4.17   54.7   NaN   
16  Djebel In-Azzene  NaN   5.00  103.0   NaN   
17       Dor el Gani  NaN    NaN   70.5   NaN   
18  Haniet-el-Beguel  NaN    NaN   83.0   NaN   
19          NWA 4233  NaN   4.82  123.0   NaN   
20          NWA 5289  NaN   4.04   90.2   111   
21      Sahara 03505  NaN   4.14   90.2   341   
22               NaN  NaN    NaN    NaN   NaN   

                                                   5                     6   \
0                                             19.2 34                  4.47   
1   17.I5AB comp<l6e0x can ge4n.7e3rally be di4s.t...                   NaN   
2                    1.63 IVAtrations of Au (>1.3 <50   15l.1 g/g), As (>10   
3                                            1.81 <50                  14.8   
4   Sb (>180 ng/g). They also required that the Ge...                   NaN   
5                                           12.4 <100                  9.71   
6   6.b1e9 in the ra1n2ge from6.05.94 to 7. If mas...                   NaN   
7   49.t3hese are 1g2e3nerally13r.o6ughly cho3n.d1...                   NaN   
8   18.t7he O-isot1o3p7ic com9p.o42sition is deter...                   NaN   
9                                                 NaN                    17   
10                            87.o2ther oxi2d2e9s0, D              O5i3s.7<   
11  44.6 Wasso1n10and Ka6ll.e0m0 eyn (20052.4) not...                   NaN   
12                              15.t0ional co1r3e00of       the3o2.r8iginal   
13  5.o8n0 Ni–Au and seve3r7a.9l other 4e7le3m0 en...                   NaN   
14  91.g2ested tha3t0t5he compositional clustering...                   NaN   
15  61.(7called the main group of IAB and abbrevia...                   NaN   
16  18.c0ould be us3e3d as examples to assess whet...                   NaN   
17                     compact compositional clusters                   NaN   
18                              67.p4lets. The27f1ull        set of closely   
19                              26.n8ated the 4I5A.0B          co1m3.p5lex.   
20                           2.0 IVAdata it is now <1  12.0 widely accepted   
21                                          21.2 32.5                   NaN   
22                               melting carbonaceous                   NaN   

                                            7      8      9     10     11  \
0                                         1.22    900   8.87  13.4  0.622   
1                                          NaN    NaN  0.149   5.7  0.863   
2      1.6l g/g), Co (>3.9 <150 l0.25 g/g) and    <20  0.222   2.8  2.708   
3                                    <100 0.22     43  0.346   3.4  2.628   
4                                          NaN    NaN    NaN   NaN    NaN   
5                                9.6 <150 0.97    474   4.34  15.6  1.036   
6                                          NaN    NaN   4.71   NaN  0.271   
7                                          NaN  If 34   1.45   4.1  1.536   
8                                          NaN    NaN   3.62   8.5  0.862   
9                                          NaN    NaN    NaN   NaN    NaN   
10           0.35& (and gen3e6ra9lly 06.752&).    305   2.42  38.0  6.480   
11                                         NaN    NaN  0.093   6.4  0.704   
12  gro7u5p.6 IAB<w23a0s quite 3c.3o5mpac5t073    NaN   58.9  83.0  3.246   
13                                         NaN    NaN  0.024   1.7  3.239   
14                                         NaN    NaN   2.68   NaN  1.760   
15                                         NaN    NaN   4.74   NaN  0.555   
16                                         NaN    NaN  0.018   NaN  2.290   
17                   were also groups or grou-    NaN    NaN   NaN    NaN   
18               related meteorites was desig-    NaN   2.40   NaN    NaN   
19               Based on O-isotopic and other    NaN   1.38   NaN   1.74   
20                0.36 that these irons formed   0 by   0.80   3.8   2.33   
21                                         NaN    NaN   3.55  0.78   1.00   
22              chondritic materials, possibly   with    NaN   NaN    NaN   

         12  
0     IIIAB  
1      IIIE  
2       NaN  
3       IVA  
4       NaN  
5       Mes  
6      ungr  
7      ungr  
8      ungr  
9       NaN  
10     ungr  
11     ungr  
12     ungr  
13     ungr  
14  IAB-sLL  
15     IIAB  
16    IIIAB  
17    IIIAB  
18   IAB-MG  
19  IAB-sLM  
20      NaN  
21      IIE  
22      NaN  ]

Process finished with exit code 0


NOTE: It is know that Tabula doe snot get all of the data. There is nothing to do about that for us.