### PR TITLE
Added a function to allow target coords to get a table.

### DIFF
--- a/external_modules/pdfScraper/table_driver_single.py
+++ b/external_modules/pdfScraper/table_driver_single.py
@@ -1,5 +1,6 @@
 import PyPDF2
 import sys
+import os
 from tabula import read_pdf
 import pandas as pd
 pd.options.display.max_rows = 999
@@ -10,12 +11,28 @@ pd.options.display.max_columns = 999
 # sys.argv[2]  = Page number
 # sys.argv[3] = Number of task to call.
 # sys.argv[4]  = Direction to flip page
+# To test use python table_driver_single.py Wasson_2010.pdf 5 0 90
 
 
 print(sys.argv[1])
 
 pdf_name = "pdfs/" + str(sys.argv[1])
 pagenum = int(sys.argv[2]) - 1
+
+
+def target_coords():
+    print(sys.argv[1])
+    pdf_name = "pdfs/" + str(sys.argv[1])
+    pdf_name = "pdfs/Wassonetal_GCA_2007.pdf"
+    pagenum = int(sys.argv[2]) - 1
+    pagenum = 5
+
+    page_in = open(pdf_name, 'rb')
+    page_reader = PyPDF2.PdfFileReader(page_in)
+    page_in.close()
+    tables_rec_from_page = read_pdf(pdf_name, output_format="dataframe", encoding="utf-8", multiple_tables=True,
+                                    pages=pagenum, silent=True, area=[521.71, 27.73, 705, 560])
+    print(tables_rec_from_page)
 
 
 def turn_page():
@@ -38,5 +55,8 @@ if int(sys.argv[3]) == 0:
     # START Get tables 1 page at a time.
     tables_rec_from_page = read_pdf('rotatedPage.pdf', output_format="dataframe", encoding="utf-8", multiple_tables=True,
                                     pages=0, silent=True)
+    os.remove("rotatedPage.pdf")
     print(tables_rec_from_page)
 
+elif int(sys.argv[3]) == 1:
+    target_coords()


### PR DESCRIPTION
Go to Command line
source activate journalImport
Go to the external_modules/pdfScraper/ dir and run
python table_driver_single.py Wasson_2010.pdf 5 1 90
This means you are passing in args for the paper name, the page you want to turn, the task you want to run and the degrees you want to rotate the page.

The output will be 

Wasson_2010.pdf
PdfReadWarning: Xref table not zero-indexed. ID numbers for objects will be corrected. [pdf.py:1736]
Feb 24, 2019 8:39:12 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font FPEKDA+AdvP4C4E74
Feb 24, 2019 8:39:13 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C29 (3) in font FPEKDA+AdvP4C4E74
Feb 24, 2019 8:39:14 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font FPEKDA+AdvP4C4E74
Feb 24, 2019 8:39:14 AM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C29 (3) in font FPEKDA+AdvP4C4E74
[                         0         1   2         3          4   5         6
0     Meteorite Area (cm2)  P (mg/g) NaN  S (mg/g)  Ir (lg/g)   G  Trap fr.
1           Ainsworth 120b       7.0 NaN       1.4      0.024  48        28
2             Braunau 200?       2.4 NaN       0.8       11.3  15         8
3               Carver 468       NaN NaN       1.7       11.3  14         3
4             Coahuila 720       NaN NaN      0.85       16.1  11         4
5        aDerrick Peak 420       3.5 NaN       2.6      0.018  46        30
6    Guadalupe y Calvo 860       NaN NaN       1.1       42.6   2        13
7     Hex River Mtns. 1680       NaN NaN       1.8       4.13  28         2
8        Keen Mountain 225       2.3 NaN       3.0       12.1  14         7
9           Mount Joy 4700       NaN NaN       1.3      0.423  39         7
10        North Chile 1600       3.0 NaN       1.0       3.43  28         3
11  Santa Luzia (Rio) 1800      6.6a NaN      12.3      0.013  48        70
12     aSanta Luzia-RSC 75       6.1 NaN       4.8      0.013  48        70
13       Sikhote-Alin >300       4.6 NaN       2.8      0.024  48        28]


This code gets a table using coordinates (that I feed into the function on this check in) and gets a table that is otherwise not possible to get. HOORAY! even though the doc says its getting Wasson, it is getting. page 5 of "Wassonetal_GCA_2007.pdf"