### PR TITLE
US794

### DIFF
--- a/controller/routes/data-entry.js
+++ b/controller/routes/data-entry.js
@@ -8,6 +8,9 @@ const path = require('path');
 const fs = require('fs');
 const pg = require('../db');
 
+const toolRouter = require('./data-entry/tool');
+router.use('/tool', toolRouter);
+
 router.get('/', isLoggedIn, function(req, res, next) {
   res.render('data-entry');
 });

--- a/controller/routes/data-entry/tool.js
+++ b/controller/routes/data-entry/tool.js
@@ -1,0 +1,22 @@
+const express = require('express');
+// eslint-disable-next-line new-cap
+const router = express.Router();
+const {isLoggedIn} = require('../../middleware/auth');
+
+router.get('/', isLoggedIn, function(req, res, next) {
+  // Root of tool router i.e. 'localhost:3001/data-entry/tool'
+  // Probably where you'd want the get for basic data used elsewhere
+  res.send('basic data requested');
+});
+
+router.get('/tables', isLoggedIn, function(req, res, next) {
+  // route to request all tables
+  res.send('all pages requested');
+});
+
+router.get('/tables/:page_number', isLoggedIn, function(req, res, next) {
+  // route to request tables on given page
+  res.send('Page number ' + req.params.page_number + ' requested');
+});
+
+module.exports = router;


### PR DESCRIPTION
US adds placeholder routes for python integration.

To test.
1. `git checkout US794`
2. Run `./iron.sh -pm`
3. login using `user1` and `password`
4. check `localhost:3001/data-entry/tool`, ``localhost:3001/data-entry/tool/tables`, and `localhost:3001/data-entry/tool/tables/7`. Expected results:
5. 
![screen shot 2019-02-26 at 10 58 07 pm](https://user-images.githubusercontent.com/6512755/53464938-12c56d80-3a1a-11e9-89e6-bc61f2a51b10.jpg)
![screen shot 2019-02-26 at 10 58 17 pm](https://user-images.githubusercontent.com/6512755/53464942-1658f480-3a1a-11e9-847d-ae7bbf7992c4.jpg)
![screen shot 2019-02-26 at 10 58 27 pm](https://user-images.githubusercontent.com/6512755/53464946-1a851200-3a1a-11e9-9917-c218e0c7b487.jpg)

