### PR TITLE
Cleaned up some of the single file and added json string output to si…

### DIFF
--- a/external_modules/pdfScraper/table_driver.py
+++ b/external_modules/pdfScraper/table_driver.py
@@ -224,20 +224,8 @@ print("Length after column cleanse:" + str(len(tables_rec_from_pages)))
 print(tables_rec_from_pages)
 
 for ind in range(len(tables_rec_from_pages)):
-    tables_rec_from_pages[ind] = tables_rec_from_pages[ind].to_json()
-    tables_rec_from_pages[ind] = {"table_" + str(ind + 1): str(tables_rec_from_pages[ind])}
+    tables_rec_from_pages[ind] = json.loads(tables_rec_from_pages[ind].to_json())
 
 print(tables_rec_from_pages)
-# table_built =
-
-
-# def table_to_json(df_list):
-#     table_json = {}
-#     if len(df_list) > 0:
-#         for x in df_list:
-#             table_json = process_tables_mark(x).to_json(orient='index')
-#     return table_json
-
-# return json.loads((table_cleaned.to_json(double_precision=10, force_ascii=True,date_unit='ms', lines=False)))
 
 


### PR DESCRIPTION
…ngle. Also muted some print statements, not all yet.


Go to Command line
source activate journalImport
Go to the external_modules/pdfScraper/ dir and run
python table_driver_single.py Wasson_2010.pdf 5 0 90

You will now have a json string representing the table that is return from the pdf and page that will look like this.


Wasson_2010.pdf
PdfReadWarning: Xref table not zero-indexed. ID numbers for objects will be corrected. [pdf.py:1736]
Mar 01, 2019 12:53:38 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C0 (3) in font JHLBFB+AdvP4C4E74
Mar 01, 2019 12:53:38 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font JHLBFB+AdvP4C4E74
Mar 01, 2019 12:53:39 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C0 (3) in font JHLBFB+AdvP4C4E74
Mar 01, 2019 12:53:39 PM org.apache.pdfbox.pdmodel.font.PDSimpleFont toUnicode
WARNING: No Unicode mapping for C24 (2) in font JHLBFB+AdvP4C4E74
[{'0': {'0': 'Zerhamra', '1': 'NWA 4704', '2': 'Kharga', '3': 'NWA 0959', '4': None, '5': 'NWA 2676', '6': 'El Qoseir', '7': 'Gebel Kamil', '8': 'NWA 0176', '9': None, '10': 'NWA 0859', '11': 'NWA 4702', '12': 'NWA 4705', '13': 'NWA 6259', '14': 'Dar al Gani 406', '15': 'Dar al Gani 413', '16': 'Djebel In-Azzene', '17': 'Dor el Gani', '18': 'Haniet-el-Beguel', '19': 'NWA 4233', '20': 'NWA 5289', '21': 'Sahara 03505'}, '1': {'0': '65', '1': '39', '2': '21', '3': '49', '4': None, '5': '412', '6': '24', '7': '32', '8': '430', '9': None, '10': '12', '11': '208', '12': '34', '13': '9', '14': None, '15': None, '16': None, '17': None, '18': None, '19': None, '20': None, '21': None}, '2': {'0': '4.95', '1': '4.89', '2': '4.37', '3': '4.27', '4': None, '5': '4.67', '6': '6.56', '7': '7.43', '8': '4.14', '9': None, '10': '12.93', '11': '4.37', '12': '13.19', '13': '6.12', '14': '4.39', '15': '4.17', '16': '5.00', '17': None, '18': None, '19': '4.82', '20': '4.04', '21': '4.14'}, '3': {'0': '78.8', '1': '89.0', '2': '117.7', '3': '94.8', '4': None, '5': '83.9', '6': '135.0', '7': '207.7', '8': '86.0', '9': None, '10': '163.4', '11': '54.3', '12': '200.1', '13': '426', '14': '67.1', '15': '54.7', '16': '103.0', '17': '70.5', '18': '83.0', '19': '123.0', '20': '90.2', '21': '90.2'}, '4': {'0': '175', '1': '154', '2': '200', '3': '128', '4': None, '5': '176', '6': '873', '7': '486', '8': '300', '9': None, '10': '291', '11': '115', '12': '339', '13': '3400', '14': None, '15': None, '16': None, '17': None, '18': None, '19': None, '20': '111', '21': '341'}, '5': {'0': '19.2 34', '1': '17.I5AB comp<l6e0x can ge4n.7e3rally be di4s.t9inguis<h1e5d0 by high0.c7o9ncen-<50', '2': '1.63 IVAtrations of Au (>1.3 <50', '3': '1.81 <50', '4': 'Sb (>180 ng/g). They also required that the Ge/Ga mass ratio', '5': '12.4 <100', '6': '6.b1e9 in the ra1n2ge from6.05.94 to 7. If massive silicates are1.p4r0esent,550', '7': '49.t3hese are 1g2e3nerally13r.o6ughly cho3n.d1ritic (=28s0ubchond0.r4i3tic).', '8': '18.t7he O-isot1o3p7ic com9p.o42sition is determine1d00from sil1i.c1a6tes or355', '9': None, '10': '87.o2ther oxi2d2e9s0, D', '11': '44.6 Wasso1n10and Ka6ll.e0m0 eyn (20052.4) note<d15th0at the 0c.o9m2 posi-<50', '12': '15.t0ional co1r3e00of', '13': '5.o8n0 Ni–Au and seve3r7a.9l other 4e7le3m0 ent-Au diagrams and sug-', '14': '91.g2ested tha3t0t5he compositional clusterings in this set of irons', '15': '61.(7called the main group of IAB and abbreviated IAB-MG)', '16': '18.c0ould be us3e3d as examples to assess whether other similarly', '17': 'compact compositional clusters', '18': '67.p4lets. The27f1ull', '19': '26.n8ated the 4I5A.0B', '20': '2.0 IVAdata it is now <1', '21': '21.2 32.5'}, '6': {'0': '4.47', '1': None, '2': '15l.1 g/g), As (>10', '3': '14.8', '4': None, '5': '9.71', '6': None, '7': None, '8': None, '9': '17', '10': 'O5i3s.7<', '11': None, '12': 'the3o2.r8iginal', '13': None, '14': None, '15': None, '16': None, '17': None, '18': 'set of closely', '19': 'co1m3.p5lex.', '20': '12.0 widely accepted', '21': None}, '7': {'0': '1.22', '1': None, '2': '1.6l g/g), Co (>3.9 <150 l0.25 g/g) and', '3': '<100 0.22', '4': None, '5': '9.6 <150 0.97', '6': None, '7': None, '8': None, '9': None, '10': '0.35& (and gen3e6ra9lly 06.752&).', '11': None, '12': 'gro7u5p.6 IAB<w23a0s quite 3c.3o5mpac5t073', '13': None, '14': None, '15': None, '16': None, '17': 'were also groups or grou-', '18': 'related meteorites was desig-', '19': 'Based on O-isotopic and other', '20': '0.36 that these irons formed', '21': None}, '8': {'0': '900', '1': None, '2': '<20', '3': '43', '4': None, '5': '474', '6': None, '7': 'If 34', '8': None, '9': None, '10': '305', '11': None, '12': None, '13': None, '14': None, '15': None, '16': None, '17': None, '18': None, '19': None, '20': '0 by', '21': None}, '9': {'0': '8.87', '1': '0.149', '2': '0.222', '3': '0.346', '4': None, '5': '4.34', '6': '4.71', '7': '1.45', '8': '3.62', '9': None, '10': '2.42', '11': '0.093', '12': '58.9', '13': '0.024', '14': '2.68', '15': '4.74', '16': '0.018', '17': None, '18': '2.40', '19': '1.38', '20': '0.80', '21': '3.55'}, '10': {'0': '13.4', '1': '5.7', '2': '2.8', '3': '3.4', '4': None, '5': '15.6', '6': None, '7': '4.1', '8': '8.5', '9': None, '10': '38.0', '11': '6.4', '12': '83.0', '13': '1.7', '14': None, '15': None, '16': None, '17': None, '18': None, '19': None, '20': '3.8', '21': '0.78'}, '11': {'0': '0.622', '1': '0.863', '2': '2.708', '3': '2.628', '4': None, '5': '1.036', '6': '0.271', '7': '1.536', '8': '0.862', '9': None, '10': '6.480', '11': '0.704', '12': '3.246', '13': '3.239', '14': '1.760', '15': '0.555', '16': '2.290', '17': None, '18': None, '19': '1.74', '20': '2.33', '21': '1.00'}, '12': {'0': 'IIIAB', '1': 'IIIE', '2': None, '3': 'IVA', '4': None, '5': 'Mes', '6': 'ungr', '7': 'ungr', '8': 'ungr', '9': None, '10': 'ungr', '11': 'ungr', '12': 'ungr', '13': 'ungr', '14': 'IAB-sLL', '15': 'IIAB', '16': 'IIIAB', '17': 'IIIAB', '18': 'IAB-MG', '19': 'IAB-sLM', '20': None, '21': 'IIE'}}]
