### PR TITLE
Us614 T781 Save work automatically when uploading pdf

### DIFF
--- a/public/javascripts/editor/save.js
+++ b/public/javascripts/editor/save.js
@@ -1,0 +1,33 @@
+
+/**
+ * @description When on the manual editor, and you choose to upload a PDF, this
+ * saves your work before continuing on.
+ */
+$(document).ready(function() {
+  $('#pdf-form').submit(function(event) {
+    event.preventDefault(); // do not submit
+    const serializedData = $('#insert-form').serializeArray();
+    const jsondata_ = {};
+    serializedData.forEach(function(element) {
+      jsondata_[element['name']] = element['value'];
+    });
+    // eslint-disable-next-line no-undef
+    const username_ = username; // username defined in ejs from route
+    // eslint-disable-next-line no-undef
+    const filename_ = filename; // filename defined in ejs from route
+
+    const jsonsend = {
+      username: username_,
+      data: jsondata_,
+      pdf_path: filename_,
+    };
+
+    // Send a post request to save the data
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/data-entry/save', true);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.send(JSON.stringify(jsonsend));
+    // eslint-disable-next-line no-invalid-this
+    this.submit(); // ok, submit
+  });
+});

--- a/views/editor.ejs
+++ b/views/editor.ejs
@@ -66,7 +66,8 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-danger mt-2 ml-2 pr-4 pl-4">Upload</button>
+                        <!-- even though the id 'modal-upload' is never called, it will break the autosave if you remove it -->
+                        <button type="submit" class="btn btn-danger mt-2 ml-2 pr-4 pl-4" id="modal-upload">Upload</button> 
                         <button type="button" class="btn btn-secondary mt-2" data-dismiss="modal">Cancel</button>
                     </div>
                 </form>
@@ -83,5 +84,6 @@
     </script>
     <script src="/javascripts/editor.js"></script>
     <script src="/javascripts/editor-modal.js"></script>
+    <script src="/javascripts/editor/save.js"></script>
 </body>
 </html>  


### PR DESCRIPTION
When on the manual editor page, if you choose to add a pdf, it saves your work in storage before changing screens.

To test:
This is branched of the latest dev as of publish date, this means you will need to rebuild the docker environment if you have not done so already. Might as well take this time to clean out docker. Delete all containers and perform initial install:
```bash
./iron.sh -xi
```

Populate the mock users `./iron.sh -m` and navigate to the manual entry page and add some data. Select upload pdf, choose any pdf, press upload.
![image](https://user-images.githubusercontent.com/17312837/53701214-4e688a80-3dc0-11e9-87b4-011416e6e713.png)
![image](https://user-images.githubusercontent.com/17312837/53701220-56282f00-3dc0-11e9-94cc-f08855e9ab21.png)
You WILL get this error message
![image](https://user-images.githubusercontent.com/17312837/53758427-5a695080-3e83-11e9-8fe0-5b2a3c49f51e.png)


Open DBVis and run `select * from entry_store` you will see your entry
![image](https://user-images.githubusercontent.com/17312837/53701231-7952de80-3dc0-11e9-8cfc-0918d7fa8b35.png)
Jumanji!