### PR TITLE
US948

### DIFF
--- a/controller/routes/database.js
+++ b/controller/routes/database.js
@@ -182,6 +182,13 @@ router.post('/', async (req, res, next) => {
       currentQueryIndex++;
     }
 
+    if (req.body.group !== 'Group') {
+      argsArray.push(req.body.group);
+      // eslint-disable-next-line max-len
+      queryString += ('AND classification_group=$' + currentQueryIndex + ' ');
+      currentQueryIndex++;
+    }
+
     if (req.body.title !== '') {
       argsArray.push(req.body.title);
       queryString += ('AND title ~* $' + currentQueryIndex + ' ');

--- a/controller/routes/index.js
+++ b/controller/routes/index.js
@@ -1,15 +1,27 @@
-const express = require('express');
-// eslint-disable-next-line new-cap
-const router = express.Router();
+const Router = require('express-promise-router');
+const router = new Router();
+const createError = require('http-errors');
+const db = require('../db');
 
 /* GET landing page. */
-router.get('/', function(req, res, next) {
-  // check if signed in
-  let isSignedIn = false;
-  if (req.isAuthenticated()) {
-    isSignedIn = true;
+router.get('/', async function(req, res, next) {
+  let resObj = [];
+  try {
+    const Groups = db.aQuery(
+        'SELECT DISTINCT classification_group FROM complete_table',
+        []
+    );
+    resObj = await Promise.all([Groups]);
+  } catch (err) {
+    next(createError(500));
+  } finally {
+    res.render('index', {
+      isSignedIn: req.isAuthenticated(),
+      Groups: resObj[0].rows,
+    });
   }
-  res.render('index', {isSignedIn: isSignedIn});
 });
 
+
 module.exports = router;
+

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -70,6 +70,15 @@
               <input type="text" name="name" id="name" class="form-control" placeholder="meteorite name">
             </div>
             <div class="col-md-2">
+              <label class="sr-only" for="group">group</label>
+              <select class="form-control" name="group">
+                <option>Group</option>
+                <% for(var i=0; i < Groups.length; i++) { %>
+                  <option value="<%= Groups[i].classification_group %>"><%= Groups[i].classification_group %></option>
+                <% } %>                
+              </select>  
+            </div>
+            <div class="col-md-2">
               <label class="sr-only" for="title">Paper Title</label>
               <input type="text" name="title" id="title" class="form-control" placeholder="paper title">
             </div>


### PR DESCRIPTION
US adds group select to landing page as per Dr. Schrader's feedback.

To test:
1. `git checkout US948`
2. Run `./iron.sh -p`
3. Navigate to `http://localhost:3001/` Check that landing page has group select prepopulated with example groups. Expected output:
![Screen Shot 2019-03-19 at 3 08 50 AM](https://user-images.githubusercontent.com/6512755/54586742-5ba68b80-49f4-11e9-84ad-542a1b471326.jpg)


4. Run a/many search(es) from the home page to test that group search field returning proper results.
