### PR TITLE
Us844 wait intelligently for containers before mock user data

### DIFF
--- a/iron.sh
+++ b/iron.sh
@@ -214,9 +214,6 @@ function wait_for_containers ()
     then
       echo ""
       echo "This operation timed out. Make sure that Docker is running and try again."
-      echo "If you are certain that the containers are running correctly, then run the following command:"
-      echo ""
-      echo "node docker/mock-users.js && python docker/mock-user-info.py "
       exit 1
     fi
   done


### PR DESCRIPTION
Changes:
Iron shell waits more intelligently for postgres and node to start up correctly
Removes dangling images and volumes during standup, this will help prevent the docker's virtual drive from getting full during testing.

Testing:
Perform these tests in order.

1) When node is broken
Select a file from the /controller/routes such as `/controller/routes/register.js` and intentionally break the file. For example, comment out line 61 so that the curly brackets are never closed.
Then run `./iron.sh -pm` 
Node will not start correctly and you will get output like this:
![image](https://user-images.githubusercontent.com/17312837/54787118-ca543680-4bf8-11e9-9c34-33ef3c1238da.png)
Depending on what you broke in node, you may get a different output such as it failing with a response code: 500 instead of 000.
Either way, if it fails, then it works, capiche? 

2) Node works - simulate initial install or db population
UNDO the changes to `/controller/routes/register.js` then run  `./iron.sh -pm` 
You should get a success message such as:
![image](https://user-images.githubusercontent.com/17312837/54787263-346cdb80-4bf9-11e9-8f03-cb78c1f1a363.png)

3) Non-deterministic  behavior - postgres is told to shut down before it's ready
This one can either fail or succeed, it's non-deterministic! It might succeed, it might fail with a bad response, or it might tell you that the database is trying to call a relation that doesn't exist. Which will you get? Only the fates can decide. Run `./iron.sh -pqm` 
Note the `q` in the middle, by performing a quick launch immediately after calling a populated launch, you sometimes make postgres go nuts.
![image](https://user-images.githubusercontent.com/17312837/54787391-9af1f980-4bf9-11e9-8e4a-6cac07b4f9ae.png)
![image](https://user-images.githubusercontent.com/17312837/54787401-a04f4400-4bf9-11e9-82ee-afddbe8509eb.png)
Either it succeeded or it failed gracefully, either of those means it worked.