### PR TITLE
Us921

### DIFF
--- a/external_modules/pdfScraper/nlp4attributes.py
+++ b/external_modules/pdfScraper/nlp4attributes.py
@@ -153,16 +153,15 @@ def title_extract(pdf_name):
         kywrd_tagword = page[page.find("doi")]
     keywords = keyword_extract(pdf_name, "Abstract", kywrd_tagword)
 
+    ##########################################################################
+    #OPTIMIZE: Organize keywords list by most significant instead of frequency
+    ##########################################################################
     for tpl in keywords:
         for kywrd in tpl[1].split():
             for line in relevant_text.split('\n\n'):
                 if any(kywrd.lower()==wrd.lower() for wrd in line.split()):
                     title_full = line
                     return title_full #find a better way to  exit nested loops
-
-    #########################################################################
-    #OPTIMIZE: Organze keywords list by most significant instead of frequency
-    #########################################################################
 
     #pattern = "NOUN-PHRASE: {<DT><NNP><NN><NN><JJ><NN><IN><DT><NNP><NN>}"
     #chunkr = nltk.RegexpParser(pattern)
@@ -208,6 +207,9 @@ def authors_extract(pdf_name):
     nerd = nltk.ne_chunk(tagged)
     line_index = 0
 
+    ###########################################################################
+    #OPTIMIZE: use recursion of author detection to check for multiline authors
+    ###########################################################################
     for line in relevant_text.split('\n\n'):
         for chunk in nerd:
             if type(chunk) == nltk.tree.Tree:
@@ -233,6 +235,7 @@ def authors_extract(pdf_name):
             if element.isdigit() or element == "*":
                 authors_full = authors_full.replace(element, "")
         authors_full = authors_full.replace(" and", ",")
+        authors_full = authors_full.replace(" ,", ",")
         authors_full = authors_full.replace(",,", ",")
         superscripts = ""
         russians = ""
@@ -292,6 +295,9 @@ def source_extract(pdf_name):
     source_tagword = "Vol"
     source = "Source not found."
 
+    ######################################################################
+    #OPTIMIZE: Pull out journal names from online catalogue and find match
+    ######################################################################
     for line in relevant_text.split('\n\n'):
         if ((source_tagword in line) or (source_tagword.lower() in line) or
             ("Acta"in line) or ("acta"in line)):
@@ -301,10 +307,6 @@ def source_extract(pdf_name):
         (source_tagword not in source.split("Copyright")[1]) and 
         (source_tagword.lower() not in source.split("Copyright")[1])):
         source = source.split("Copyright")[0]
-
-    ######################################################################
-    #OPTIMIZE: Pull out journal names from online catalogue and find match
-    ######################################################################
 
     return source
 


### PR DESCRIPTION
This is a patch for author(s) extraction to detect and remove superscripts, as well as account for authors that span multiple lines. It currently works for the 3 papers for alpha: Wassonetal_GCA_2007.pdf, WassonandChoe_GCA_2009.pdf, Litasov2018_Article_TraceElementCompositionAndClas.pdf. It should work for other papers as well but no guarantees. **The  2018 paper illustrates those changes perfectly so we will use it for testing.**

To Test:

1. git checkout US921
2. cd irondb/external_modules/pdfScraper
3. source activate journalImport
4. python nlp4attributes.py
5. enter: Litasov2018_Article_TraceElementCompositionAndClas.pdf
6. Verify that it returns all authors of the paper with no superscripts attached to the end of each author.
7. Optional: repeat steps 3-5 for the other 2 papers.
8. Done. Results should look like the stuff below:

<img width="571" alt="Screen Shot 2019-03-23 at 11 19 45 AM" src="https://user-images.githubusercontent.com/26435230/54870171-2e453f00-4d60-11e9-8026-bd14e993e859.png">
