### PR TITLE
Us1030 hot fix server, install pip

### DIFF
--- a/iron.sh
+++ b/iron.sh
@@ -58,7 +58,6 @@ fi
 # Install the global dependencies
 function install_global_deps ()
 {
-  install_pip
   echo "Installing global dependencies"
   # Global dependencies for testing node
   if [[ $EUID -ne 0 ]];


### PR DESCRIPTION
Because this fix addresses an issue for digitalocean, I implore you to read the explanation so that you understand why I am asking you to test it the way I am.

Explanation: The call to ` ./iron.sh -m ` relies on a python library that is installed by pip outside of the docker containers, but pip is not installed on digitalocean's  ubuntu 18.04 image. This checks for pip, installing the version of pip that matches the version of python installed as the system python, using apt-get to install pip.
This check also has a separate logic branch for macOS which calls the system python directly to install pip. This is strictly for dev environments.
Windows, I think we need to recognize that no one on the team is developing for windows anymore and that it's unreasonable to expect a bash script to support Windows at this point.
I am assuming that the server and dev environments have python installed, this is a reasonable assumption as Ubuntu and macOS both ship with a version of python.

Testing: Testing for this will be cursory as I don't expect the testers to spin up several different environments without pip installed.

Testing for linux (DO THIS!) ---
Navigate to ` http://159.203.92.9:3001/login ` and log in as `user1` / `password`
If you can log in as user1, that means that calling `./iron.sh -m` from within the server had to check for pip, install pip, check for python import psycopg2, install psycopg2, then run the python script that generates mock user information.

Testing for mac ---
Run ` ./iron.sh -pm `, since you should already have pip installed, it won't try to install pip.
![image](https://user-images.githubusercontent.com/17312837/55113333-d8003500-50ac-11e9-8b4b-5c8d2e43225b.png)
For macOS, the shell makes a call to ` python -m ensurepip `, so go ahead and run that command. 
The expected output will be similar to this, but can be very different
![image](https://user-images.githubusercontent.com/17312837/55113515-77252c80-50ad-11e9-96fe-1f5e567d733b.png)
The reason that this command is not used under the linux logic is because ubuntu doesn't allow it:
![image](https://user-images.githubusercontent.com/17312837/55113793-34178900-50ae-11e9-9395-4aba8339332b.png)

