### PR TITLE
AttributesJSON

### DIFF
--- a/external/pdfScraper/nlp4attributes.py
+++ b/external/pdfScraper/nlp4attributes.py
@@ -218,14 +218,14 @@ def authors_extract(pdf_name):
                     if (english_author in line) and (len(line.split()) > 1):
                         authors_full = line
                     if authors_full.endswith(","):
-                    	authors_full += " " + relevant_text.split('\n\n')[line_index+1]
+                    	authors_full += relevant_text.split('\n\n')[line_index+1]
         if authors_full == "":
             for word in tagged:
                 if ((word[0] not in words.words()) and (word[1] == 'NNP') and 
                     (word[0] in line) and (len(line.split()) > 1)):
                     authors_full = line
                 if authors_full.endswith(","):
-                	authors_full += " " + relevant_text.split('\n\n')[line_index+1]
+                	authors_full += relevant_text.split('\n\n')[line_index+1]
         line_index += 1
 
     if authors_full == "":
@@ -259,6 +259,9 @@ def authors_extract(pdf_name):
     #authors_tagword = truncated_authors(pdf_name).split()[1].replace(",", "")
     #authors_index = (relevant_text.lower()).find(authors_tagword.lower())
     #authors_full = relevant_text[:authors_index].rsplit('\n\n', 1)[1] + relevant_text[authors_index:].split('\n', 1)[0]
+
+    if authors_full.endswith(" "):
+        authors_full = authors_full[:-1]
 
     return authors_full
 


### PR DESCRIPTION
This prints the attributes in a json for easier data transfer. We will test it on WassonandChoe_GCA_2009.pdf because that gives the quickest results. It should work for any paper from which the script can extract all attributes.

To Test:

1. git checkout AttributesJSON
2. cd irondb/external/pdfScraper
3. source activate journalImport
4. python nlp4attributes.py
5. enter: WassonandChoe_GCA_2009.pdf
6. Verify that it returns all attributes of the paper in a json.
7. Done. Results should look like the stuff below:

<img width="523" alt="Screen Shot 2019-04-06 at 10 18 51 PM" src="https://user-images.githubusercontent.com/26435230/55679088-128e7c80-58ba-11e9-968d-f4e00ae4e554.png">
