### PR TITLE
I added a new logic to filter bad info out of tables by changing the …

### DIFF
--- a/external/pdfScraper/table_cleaner.py
+++ b/external/pdfScraper/table_cleaner.py
@@ -1,4 +1,6 @@
 import pandas as pd
+from periodictable import elements
+import re
 
 
 def row_by_row(mdf, mdf2):
@@ -44,8 +46,20 @@ def mark_fields_for_removal(tables_for_marking):
         for table_df in tables_for_marking:
             for removal_row in range(table_df.shape[0]):
                 for removal_col in range(table_df.shape[1]):
-                    if len(str(table_df.iat[removal_row, removal_col])) > 20:
-                        table_df.iat[removal_row, removal_col] = "REMOVE"
+                    if not str(table_df.iat[removal_row, removal_col]) == 'nan':
+                        print("Before clean: " + str(table_df.iat[removal_row, removal_col]))
+                        print("Type: " + str(type(table_df.iat[removal_row, removal_col])))
+                        print("Is Element: " + str(is_element(str(table_df.iat[removal_row, removal_col]))))
+                        print("Is Number: " + str(is_number(str(table_df.iat[removal_row, removal_col]))))
+                        print("Is Measurement: " + str(is_measurement(str(table_df.iat[removal_row, removal_col]))))
+                        print("Is Proper Name: " + str(is_proper_name(str(table_df.iat[removal_row, removal_col]))))
+                        # if not is_element(str(table_df.iat[removal_row, removal_col])) \
+                        #         and not is_number(str(table_df.iat[removal_row, removal_col])) \
+                        #         and not is_measurement(str(table_df.iat[removal_row, removal_col])) \
+                        #         and not is_proper_name(str(table_df.iat[removal_row, removal_col])):
+                        if len(str(table_df.iat[removal_row, removal_col])) > 20:
+                            table_df.iat[removal_row, removal_col] = 'REMOVE'
+                        print("After clean: " + str(table_df.iat[removal_row, removal_col]))
     return tables_for_marking
 # End Marking the fields for removal
 
@@ -69,3 +83,34 @@ def marked_field_clean_up(tables_dirty, tables_clean):
                     if str(tables_dirty[tt].iat[row, col]) == "REMOVE":
                         tables_dirty[tt].iat[row, col] = tables_clean[tt].iat[row, col]
 # END Put original values back in fields marked for removal by mistake
+
+
+def is_element(df_value):
+    el_list = []
+    for el in elements:
+        el_list.append(str(el.symbol))
+    for each_el in el_list:
+        if bool(re.search(r'\s' + each_el + '\s', " " + df_value + " ") and len(str(df_value)) < 10):
+            return True
+    return False
+
+
+def is_number(df_value):
+    if bool(re.search(r'^\d+|<\d+', df_value) and len(str(df_value)) < 6):
+        return True
+    return False
+
+
+def is_measurement(df_value):
+    if bool(re.search(r'^\\g|mg|lg|ng', df_value) and len(str(df_value)) < 10):
+        return True
+    return False
+
+
+def is_proper_name(df_value):
+    cap_letters = re.findall(r'[A-Z]', df_value)
+    words = df_value.split()
+    if len(cap_letters) >= len(words):
+        return True
+    return False
+

--- a/external/pdfScraper/table_driver.py
+++ b/external/pdfScraper/table_driver.py
@@ -11,12 +11,12 @@ __date__ = "11/7/18"
 import PyPDF2
 from tabula import read_pdf
 import re
+import sys
 from copy import deepcopy
 import json
 import pdf_text_import as pti
 import table_cleaner as tc
 import table_page_finder as tpf
-
 
 pdf = ["pdfs/WassonandRichardson_GCA_2011.pdf",
        "pdfs/WassonandChoe_GCA_2009.pdf",
@@ -30,24 +30,36 @@ pdf = ["pdfs/WassonandRichardson_GCA_2011.pdf",
        "pdfs/WassonandKallemeyn_GCA_2002.pdf",
        "pdfs/RuzickaandHutson2010.pdf"]
 
-chosen_pdf = pdf[0]
-print(chosen_pdf)
+fileName = pdf[9]
+# print(fileName)
+
+# j = json.loads(sys.argv[1])
+# fileName = j['fileName']
+# fileName = '/usr/app/controller/py/WassonandChoe_GCA_2009.pdf'
+# pageNum = int(j['pageNum'])
+# taskNum = int(j['taskNum'])
+# flipDir = int(j['flipDir'])
+# coordsLeft = j['coordsLeft']
+# coordsTop = j['coordsTop']
+# coordsWidth = j['coordsWidth']
+# coordsHeight = j['coordsHeight']
+
 
 tables = []
 json_pages_confirmed = []
 
 # START Get number of Pages
-total_pages = PyPDF2.PdfFileReader(open(chosen_pdf, 'rb')).numPages
+total_pages = PyPDF2.PdfFileReader(open(fileName, 'rb')).numPages
 
 # START get text from pdf
-text = pti.convert_pdf_to_txt_looper(chosen_pdf, total_pages)
+text = pti.convert_pdf_to_txt_looper(fileName, total_pages)
 
 # START Finding pages that have tables on them.
 json_pages = tpf.find_pages_with_tables(total_pages, text)
 
 # START Get tables 1 page at a time.
 for page in range(len(json_pages)):
-    one_page_of_tables = read_pdf(chosen_pdf, output_format="dataframe", encoding="utf-8", multiple_tables=True,
+    one_page_of_tables = read_pdf(fileName, output_format="dataframe", encoding="utf-8", multiple_tables=True,
                                   pages=json_pages[page]["pdf_page"], silent=True)
     if one_page_of_tables:
         for table in one_page_of_tables:
@@ -86,5 +98,5 @@ for ind in range(len(tables)):
     tables[ind] = '{\"actual_page\":' + str(json_pages_confirmed[ind]["actual_page"]) \
                   + ',\"pdf_page\": ' + str(json_pages_confirmed[ind]["pdf_page"]) \
                   + ', \"Table\":' + tables[ind].to_json() + '}'
-    print(tables[ind])
-# print(tables_rec_from_pages)
+    # print(tables[ind])
+print(tables)


### PR DESCRIPTION
…criteria that constitues a REMOVE mark in a filed.



To run:
Go to Command line
source activate journalImport
run pip install periodictable if you need to. (This is installed in our web application env, but might not be installed to your local machine.)
Go to the external/pdfScraper/ dir and run
python table_driver.py
You will see a whole bunch of test text that shows that the text that is valid table DB that we want to go to the DB tests positive when appropriate.

For example

THE FOLLOWING SHOWS THAT IT IS NOT RELEVANT TEXT AND IS MARKED FOR REMOVAL:
Before clean: and that three different specimens of Twannberg were
Is Element: False
Is Number: False
Is Measurement: False
Is Proper Name: False
After clean: REMOVE

THE FOLLOWING SHOWS THAT IT IS AN ELEMENT, SO IT IS KEPT:
Before clean: Cr
Is Element: True
Is Number: False
Is Measurement: False
Is Proper Name: True
After clean: Cr

THE FOLLOWING IS A NUMBER, SO IT IS KEPT:
Before clean: 5.08
Is Element: False
Is Number: True
Is Measurement: False
Is Proper Name: False
After clean: 5.08

THE FOLLOWING IS A MEASUREMENT, SO IT IS KEPT:
Before clean: mg/g
Is Element: False
Is Number: False
Is Measurement: True
Is Proper Name: False
After clean: mg/g

THE FOLLOWING IS A PROPER NAME, SO IT IS KEPT:
Before clean: Bellsbank
Is Element: False
Is Number: False
Is Measurement: False
Is Proper Name: True
After clean: Bellsbank