### PR TITLE
Updated validations for elements and meteorite names

### DIFF
--- a/controller/py/validations.py
+++ b/controller/py/validations.py
@@ -23,14 +23,14 @@ data = json.loads(sys.argv[1])
 
 
 # checks if a periodic element is valid using an external catalogue
-def is_element(df_value):
-    el_list = []
-    for el in elements:
-        el_list.append(str(el.symbol))
-    for each_el in el_list:
-        if bool(re.search(r'\s' + each_el + '\s', " " + df_value + " ") and len(str(df_value)) < 10):
-            return True
-    return False
+def is_element(value):
+	el_list = []
+	for el in elements:
+		el_list.append(str(el.symbol))
+	if value in el_list:
+		return True
+
+	return False
 
 
 # validates all data staged for import into the database
@@ -104,7 +104,7 @@ def form_validate(form):
 
 		# validates single meteorite entries
 		if 'bodyName' in key or 'group' in key:
-			if any(word.isalpha() for word in form[key].split()):
+			if any(letter.isalpha() for letter in form[key]):
 				form[key] = "success"
 			else:
 				form[key] = "invalid"
@@ -156,7 +156,7 @@ def form_validate(form):
 
 									else:
 										if k2 == 'meteorite_name':
-											if any(word.isalpha() for word in v2.split()):
+											if any(letter.isalpha() for letter in v2):
 												cell[k2] = "success"
 											else:
 												cell[k2] = "invalid"


### PR DESCRIPTION
US updates the way elements are validated to be more strict.

To test:
1. `git checkout US1248`
2. Run `./iron.sh -lepm` if not rebuilding 
3. Navigate to login and login in with user `user1` and password `password`
4. Navigate to Data-entry. Select with pdf, select Wasson and choe 2009, select all tables. Submit:
5. Validate and check the table on page 8. Checking that only element symbols are valid (strict).
The table to check is page 8, this is what the table looked like before this pr:
![Screen Shot 2019-04-23 at 3 17 21 AM](https://user-images.githubusercontent.com/6512755/56562016-6ebdf580-6576-11e9-90e5-eb4b4e067a99.jpg)

**Expected with this pr:**
![Screen Shot 2019-04-23 at 3 24 46 AM](https://user-images.githubusercontent.com/6512755/56562523-88ac0800-6577-11e9-8534-0b3b7067f25e.jpg)

6. Next check that meteorite names in tables are valid if the contain one letter. Type in something like "V340" in one of the meteorite names and validate again, cell should appear green.

**Valid Example:**
![Screen Shot 2019-04-23 at 3 29 45 AM](https://user-images.githubusercontent.com/6512755/56562907-87c7a600-6578-11e9-8170-6d571e1d2a25.jpg)

**Invalid Example:**
![Screen Shot 2019-04-23 at 3 31 51 AM](https://user-images.githubusercontent.com/6512755/56562921-8dbd8700-6578-11e9-8bc1-9b85bea074c6.jpg)



7. Go back to data-entry and select with pdf, select attributes only. Insert a meteorite name of "V340", validate.
meteorite names in single meteorite entries are valid if the contain one letter.

**Valid Example:**
![Screen Shot 2019-04-23 at 3 30 13 AM](https://user-images.githubusercontent.com/6512755/56562999-b9407180-6578-11e9-8af3-f9e5c6fe3660.jpg)

**Invalid Example:**
![Screen Shot 2019-04-23 at 3 30 21 AM](https://user-images.githubusercontent.com/6512755/56563026-c1001600-6578-11e9-84a3-0c32b2e72aef.jpg)


